### PR TITLE
Embedding the airtable base into index.html

### DIFF
--- a/vaccine-standby-list/.env
+++ b/vaccine-standby-list/.env
@@ -13,4 +13,10 @@ AIRTABLE_API_KEY=
 # format: text
 # link: https://airtable.com/api
 # required: true
-AIRTABLE_BASE_ID=appAbcD12efG3HijK
+AIRTABLE_BASE_ID=
+
+# description: Your Airtable Embed Code
+# format: text
+# link: https://support.airtable.com/hc/en-us/articles/217846478-Embedding-a-view-or-base
+# required: true
+AIRTABLE_EMBED_CODE=

--- a/vaccine-standby-list/assets/index.html
+++ b/vaccine-standby-list/assets/index.html
@@ -68,6 +68,7 @@
       </section>
 			<section>
 				<h3>Registered Residents</h3>
+        <div id="airtable-embedded-iframe-container"></div>
 			</section>
       <section>
         <h3>Troubleshooting</h3>
@@ -118,6 +119,15 @@
       functionRoots.forEach(element => {
         element.innerText = fullUrl
       })
+      // Grab the Airtable embed code and use it to populate the iFrame to embed the base
+      let request = new XMLHttpRequest();
+      request.open('GET', fullUrl + '/return-airtable-config');
+      request.send();
+      request.onload = () => {
+        const airtable_embed_code = JSON.parse(request.response).airtable_embed_code;
+        const iframe_container = document.getElementById('airtable-embedded-iframe-container');
+        iframe_container.innerHTML = airtable_embed_code;
+      }
     </script>
   </body>
 </html>

--- a/vaccine-standby-list/functions/return-airtable-config.js
+++ b/vaccine-standby-list/functions/return-airtable-config.js
@@ -1,0 +1,8 @@
+exports.handler = function(context, event, callback) {
+  let airtable_embed_code = context.AIRTABLE_EMBED_CODE;
+  let response = new Twilio.Response();
+  response.setStatusCode(200);
+  response.appendHeader('Content-Type', 'application/json');
+  response.setBody({'airtable_embed_code': airtable_embed_code});
+  callback(null, response);
+};


### PR DESCRIPTION
So users can see records being stored in real time. NOTE: Requires a new config variable which is the iFrame string from a shared view in Airtable.

![Screen Shot 2021-02-05 at 5 10 30 PM](https://user-images.githubusercontent.com/4605360/107104181-62e80580-67d5-11eb-8ae2-30b42ffaba0f.png)
